### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ SEL selector = @selector(calculate:);
 [RSSwizzle
  swizzleInstanceMethod:selector
  inClass:classToSwizzle
- newImpFactory:^id(RSSWizzleInfo *swizzleInfo) {
+ newImpFactory:^id(RSSwizzleInfo *swizzleInfo) {
      // This block will be used as the new implementation.
      return ^int(__unsafe_unretained id self, int num){
          // You MUST always cast implementation to the correct function pointer.


### PR DESCRIPTION
Typo in the non macro api example. RSSWizzle should be RSSwizzle. This causes the example not to compile. Considering the code is complicated, it's hard to catch this.
