### PR TITLE
Tweak type safety check to support block arguments

### DIFF
--- a/RSSwizzle/RSSwizzle.m
+++ b/RSSwizzle/RSSwizzle.m
@@ -126,7 +126,11 @@ static BOOL blockIsCompatibleWithMethodType(id block, const char *methodType){
         }else {
             const char *blockSignatureArg = [blockSignature getArgumentTypeAtIndex:i];
             
-            if (strncmp(blockSignatureArg, "@", 1) == 0) {
+            if (strncmp(blockSignatureArg, "@?", 2) == 0) {
+                // Handle function pointer / block arguments
+                blockSignatureArg = "@?";
+            }
+            else if (strncmp(blockSignatureArg, "@", 1) == 0) {
                 blockSignatureArg = "@";
             }
             


### PR DESCRIPTION
Hi,
I had to make a small change to the type safety checks (which are very awesome by the way) to allow hooking methods that have blocks as arguments (ie. type signature @?). 
Without this change, the following assertion fails when hooking a method that has block arguments: 

```
NSCAssert(blockIsCompatibleWithMethodType(newIMPBlock,methodType),
         @"Block returned from factory is not compatible with method type.");
```

Specifically, when inspecting the type of a block argument, RSSwizzle expects a type of @ but gets @?, resulting in blockIsCompatibleWithMethodType() returning NO. Hopefully I didn't break anything with this change.
Thanks for the great library!
