### PR TITLE
Switch from deprecated OSSpinLock to os_unfair_lock

### DIFF
--- a/RSSwizzle/RSSwizzle.m
+++ b/RSSwizzle/RSSwizzle.m
@@ -18,7 +18,7 @@
 #else
 //use this struct to inialize an unfair_lock
 typedef struct _os_unfair_lock_s {
-uint32_t _os_unfair_lock_opaque;
+    uint32_t _os_unfair_lock_opaque;
 } os_unfair_lock, *os_unfair_lock_t;
 #endif
 
@@ -31,7 +31,7 @@ uint32_t _os_unfair_lock_opaque;
 #pragma mark Locking
 
 // This function will lock a lock using os_unfair_lock_lock (on ios10/macos10.12) or OSSpinLockLock (9 and lower).
-void chooseLock(void *lock)
+static void chooseLock(void *lock)
 {
 #if TARGET_SDK_GE_10
     // iOS 10+, os_unfair_lock_lock is available
@@ -56,7 +56,7 @@ void chooseLock(void *lock)
 }
 
 // This function will unlock a lock using os_unfair_lock_unlock (on ios10/macos10.12) or OSSpinLockUnlock (9 and lower).
-void chooseUnlock(void *lock)
+static void chooseUnlock(void *lock)
 {
 #if TARGET_SDK_GE_10
     // iOS 10+, os_unfair_lock_unlock is available
@@ -268,7 +268,7 @@ static void swizzle(Class classToSwizzle,
     // Below iOS 10, OS_UNFAIR_LOCK_INIT will not exist. Note that this type works with OSSpinLock
     __block os_unfair_lock lock = ((os_unfair_lock){0});
 #endif
-
+    
     // To keep things thread-safe, we fill in the originalIMP later,
     // with the result of the class_replaceMethod call below.
     __block IMP originalIMP = NULL;
@@ -279,7 +279,7 @@ static void swizzle(Class classToSwizzle,
         // class_replaceMethod and its return value being set.
         // So to be sure originalIMP has the right value, we need a lock.
         
-
+        
         chooseLock(&lock);
         
         IMP imp = originalIMP;

--- a/RSSwizzle/RSSwizzle.m
+++ b/RSSwizzle/RSSwizzle.m
@@ -8,19 +8,77 @@
 
 #import "RSSwizzle.h"
 #import <objc/runtime.h>
+#include <dlfcn.h>
 
-//use os_unfair_lock over OSSpinLock when building with ios sdk 10 or osx sdk 10.12
-#define TARGET_SDK_GE_10 ((TARGET_OS_IOS &&__IPHONE_OS_VERSION_MAX_ALLOWED >= 100000) || (!TARGET_OS_IPHONE && __MAC_OS_X_VERSION_MAX_ALLOWED >= 101200))
+// Use os_unfair_lock over OSSpinLock when building with ios sdk 10 or macos sdk 10.12
+#define TARGET_SDK_GE_10 ((TARGET_OS_IOS && __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000) || (!TARGET_OS_IPHONE && __MAC_OS_X_VERSION_MAX_ALLOWED >= 101200))
 
 #if TARGET_SDK_GE_10
 #import <os/lock.h>
 #else
-#import <libkern/OSAtomic.h>
+//use this struct to inialize an unfair_lock
+typedef struct _os_unfair_lock_s {
+uint32_t _os_unfair_lock_opaque;
+} os_unfair_lock, *os_unfair_lock_t;
 #endif
+
+#import <libkern/OSAtomic.h>
 
 #if !__has_feature(objc_arc)
 #error This code needs ARC. Use compiler option -fobjc-arc
 #endif
+
+#pragma mark Locking
+
+// This function will lock a lock using os_unfair_lock_lock (on ios10/macos10.12) or OSSpinLockLock (9 and lower).
+void chooseLock(void *lock)
+{
+#if TARGET_SDK_GE_10
+    // iOS 10+, os_unfair_lock_lock is available
+    os_unfair_lock_lock(lock);
+#else
+    // NSDimension was introduced at the same time that os_unfair_lock_lock was made public.
+    // To make sure we dont access unfair_lock on an iOS version where it isnt public, check for the presence of NSDimension before proceeding.
+    if (objc_getClass("NSDimension"))
+    {
+        // Attempt to use 'os_unfair_lock_lock'
+        void (*os_unfair_lock_lock)(void *lock) = dlsym(dlopen(NULL, RTLD_NOW | RTLD_GLOBAL), "os_unfair_lock_lock");
+        if (os_unfair_lock_lock != NULL)
+        {
+            os_unfair_lock_lock(lock);
+            return;
+        }
+    }
+    
+    // Unfair locks are not available on iOS 9 and lower, using deprecated OSSpinLock.
+    OSSpinLockLock(lock);
+#endif
+}
+
+// This function will unlock a lock using os_unfair_lock_unlock (on ios10/macos10.12) or OSSpinLockUnlock (9 and lower).
+void chooseUnlock(void *lock)
+{
+#if TARGET_SDK_GE_10
+    // iOS 10+, os_unfair_lock_unlock is available
+    os_unfair_lock_unlock(lock);
+#else
+    // NSDimension was introduced at the same time that os_unfair_lock_unlock was made public.
+    // To make sure we dont access unfair_unlock on an iOS version where it isnt public, check for the presence of NSDimension before proceeding.
+    if (objc_getClass("NSDimension"))
+    {
+        // Attempt to use 'os_unfair_lock_unlock'.
+        void (*os_unfair_lock_unlock)(void *lock) = dlsym(dlopen(NULL, RTLD_NOW | RTLD_GLOBAL), "os_unfair_lock_unlock");
+        if (os_unfair_lock_unlock != NULL)
+        {
+            os_unfair_lock_unlock(lock);
+            return;
+        }
+    }
+    
+    // Unfair locks are not available on iOS 9 and lower, using deprecated OSSpinUnlock.
+    OSSpinLockUnlock(lock);
+#endif
+}
 
 #pragma mark - Block Helpers
 #if !defined(NS_BLOCK_ASSERTIONS)
@@ -207,9 +265,10 @@ static void swizzle(Class classToSwizzle,
 #if TARGET_SDK_GE_10
     __block os_unfair_lock lock = OS_UNFAIR_LOCK_INIT;
 #else
-    __block OSSpinLock lock = OS_SPINLOCK_INIT;
+    // Below iOS 10, OS_UNFAIR_LOCK_INIT will not exist. Note that this type works with OSSpinLock
+    __block os_unfair_lock lock = ((os_unfair_lock){0});
 #endif
-    
+
     // To keep things thread-safe, we fill in the originalIMP later,
     // with the result of the class_replaceMethod call below.
     __block IMP originalIMP = NULL;
@@ -220,18 +279,12 @@ static void swizzle(Class classToSwizzle,
         // class_replaceMethod and its return value being set.
         // So to be sure originalIMP has the right value, we need a lock.
         
-#if TARGET_SDK_GE_10
-        os_unfair_lock_lock(&lock);
-#else
-        OSSpinLockLock(&lock);
-#endif
+
+        chooseLock(&lock);
+        
         IMP imp = originalIMP;
         
-#if TARGET_SDK_GE_10
-        os_unfair_lock_unlock(&lock);
-#else
-        OSSpinLockUnlock(&lock);
-#endif
+        chooseUnlock(&lock);
         
         if (NULL == imp){
             // If the class does not implement the method
@@ -268,20 +321,11 @@ static void swizzle(Class classToSwizzle,
     // We need a lock to be sure that originalIMP has the right value in the
     // originalImpProvider block above.
     
-#if TARGET_SDK_GE_10
-    os_unfair_lock_lock(&lock);
-#else
-    OSSpinLockLock(&lock);
-#endif
+    chooseLock(&lock);
     
     originalIMP = class_replaceMethod(classToSwizzle, selector, newIMP, methodType);
     
-#if TARGET_SDK_GE_10
-    os_unfair_lock_unlock(&lock);
-#else
-    OSSpinLockUnlock(&lock);
-#endif
-    
+    chooseUnlock(&lock);
 }
 
 
@@ -353,6 +397,5 @@ static NSMutableSet *swizzledClassesForKey(const void *key){
                            mode:RSSwizzleModeAlways
                             key:NULL];
 }
-
 
 @end

--- a/RSSwizzle/RSSwizzle.m
+++ b/RSSwizzle/RSSwizzle.m
@@ -8,7 +8,15 @@
 
 #import "RSSwizzle.h"
 #import <objc/runtime.h>
+
+//use os_unfair_lock over OSSpinLock when building with ios sdk 10 or osx sdk 10.12
+#define TARGET_SDK_GE_10 ((TARGET_OS_IOS &&__IPHONE_OS_VERSION_MAX_ALLOWED >= 100000) || (!TARGET_OS_IPHONE && __MAC_OS_X_VERSION_MAX_ALLOWED >= 101200))
+
+#if TARGET_SDK_GE_10
 #import <os/lock.h>
+#else
+#import <libkern/OSAtomic.h>
+#endif
 
 #if !__has_feature(objc_arc)
 #error This code needs ARC. Use compiler option -fobjc-arc
@@ -92,7 +100,7 @@ static BOOL blockIsCompatibleWithMethodType(id block, const char *methodType){
     }
     
     NSMethodSignature *methodSignature =
-        [NSMethodSignature signatureWithObjCTypes:methodType];
+    [NSMethodSignature signatureWithObjCTypes:methodType];
     
     if (!blockSignature || !methodSignature) {
         return NO;
@@ -194,21 +202,36 @@ static void swizzle(Class classToSwizzle,
               classToSwizzle);
     
     NSCAssert(blockIsAnImpFactoryBlock(factoryBlock),
-             @"Wrong type of implementation factory block.");
+              @"Wrong type of implementation factory block.");
     
+#if TARGET_SDK_GE_10
     __block os_unfair_lock lock = OS_UNFAIR_LOCK_INIT;
+#else
+    __block OSSpinLock lock = OS_SPINLOCK_INIT;
+#endif
+    
     // To keep things thread-safe, we fill in the originalIMP later,
     // with the result of the class_replaceMethod call below.
     __block IMP originalIMP = NULL;
-
+    
     // This block will be called by the client to get original implementation and call it.
     RSSWizzleImpProvider originalImpProvider = ^IMP{
         // It's possible that another thread can call the method between the call to
         // class_replaceMethod and its return value being set.
         // So to be sure originalIMP has the right value, we need a lock.
+        
+#if TARGET_SDK_GE_10
         os_unfair_lock_lock(&lock);
+#else
+        OSSpinLockLock(&lock);
+#endif
         IMP imp = originalIMP;
+        
+#if TARGET_SDK_GE_10
         os_unfair_lock_unlock(&lock);
+#else
+        OSSpinLockUnlock(&lock);
+#endif
         
         if (NULL == imp){
             // If the class does not implement the method
@@ -231,7 +254,7 @@ static void swizzle(Class classToSwizzle,
     const char *methodType = method_getTypeEncoding(method);
     
     NSCAssert(blockIsCompatibleWithMethodType(newIMPBlock,methodType),
-             @"Block returned from factory is not compatible with method type.");
+              @"Block returned from factory is not compatible with method type.");
     
     IMP newIMP = imp_implementationWithBlock(newIMPBlock);
     
@@ -244,10 +267,23 @@ static void swizzle(Class classToSwizzle,
     //
     // We need a lock to be sure that originalIMP has the right value in the
     // originalImpProvider block above.
+    
+#if TARGET_SDK_GE_10
     os_unfair_lock_lock(&lock);
+#else
+    OSSpinLockLock(&lock);
+#endif
+    
     originalIMP = class_replaceMethod(classToSwizzle, selector, newIMP, methodType);
+    
+#if TARGET_SDK_GE_10
     os_unfair_lock_unlock(&lock);
+#else
+    OSSpinLockUnlock(&lock);
+#endif
+    
 }
+
 
 static NSMutableDictionary *swizzledClassesDictionary(){
     static NSMutableDictionary *swizzledClasses;
@@ -277,7 +313,7 @@ static NSMutableSet *swizzledClassesForKey(const void *key){
 {
     NSAssert(!(NULL == key && RSSwizzleModeAlways != mode),
              @"Key may not be NULL if mode is not RSSwizzleModeAlways.");
-
+    
     @synchronized(swizzledClassesDictionary()){
         if (key){
             NSSet *swizzledClasses = swizzledClassesForKey(key);

--- a/RSSwizzle/RSSwizzle.m
+++ b/RSSwizzle/RSSwizzle.m
@@ -24,6 +24,13 @@
 
 #if BASE_SDK_HIGHER_THAN_10
 #import <os/lock.h>
+#else
+// Below iOS 10, OS_UNFAIR_LOCK_INIT will not exist. Note that this type works with OSSpinLock
+#define OS_UNFAIR_LOCK_INIT ((os_unfair_lock){0})
+
+typedef struct _os_unfair_lock_s {
+    uint32_t _os_unfair_lock_opaque;
+} os_unfair_lock, *os_unfair_lock_t;
 #endif
 
 
@@ -32,20 +39,22 @@
 #endif
 
 
+// NSDimension was introduced at the same time that os_unfair_lock_lock was made public, ie. iOS 10
+#define DEVICE_HIGHER_THAN_10 objc_getClass("NSDimension")
+
+
 #pragma mark Locking
 
 // This function will lock a lock using os_unfair_lock_lock (on ios10/macos10.12) or OSSpinLockLock (9 and lower).
-static void chooseLock(void *lock)
+static void chooseLock(os_unfair_lock *lock)
 {
 #if DEPLOYMENT_TARGET_HIGHER_THAN_10
     // iOS 10+, os_unfair_lock_lock is available
     os_unfair_lock_lock(lock);
 #else
-    // NSDimension was introduced at the same time that os_unfair_lock_lock was made public.
-    // To make sure we dont access unfair_lock on an iOS version where it isnt public, check for the presence of NSDimension before proceeding.
-    if (objc_getClass("NSDimension"))
+    if (DEVICE_HIGHER_THAN_10)
     {
-        // Attempt to use 'os_unfair_lock_lock'
+        // Attempt to use os_unfair_lock_lock().
         void (*os_unfair_lock_lock)(void *lock) = dlsym(dlopen(NULL, RTLD_NOW | RTLD_GLOBAL), "os_unfair_lock_lock");
         if (os_unfair_lock_lock != NULL)
         {
@@ -55,22 +64,20 @@ static void chooseLock(void *lock)
     }
     
     // Unfair locks are not available on iOS 9 and lower, using deprecated OSSpinLock.
-    OSSpinLockLock(lock);
+    OSSpinLockLock((void *)lock);
 #endif
 }
 
 // This function will unlock a lock using os_unfair_lock_unlock (on ios10/macos10.12) or OSSpinLockUnlock (9 and lower).
-static void chooseUnlock(void *lock)
+static void chooseUnlock(os_unfair_lock *lock)
 {
 #if DEPLOYMENT_TARGET_HIGHER_THAN_10
     // iOS 10+, os_unfair_lock_unlock is available
     os_unfair_lock_unlock(lock);
 #else
-    // NSDimension was introduced at the same time that os_unfair_lock_unlock was made public.
-    // To make sure we dont access unfair_unlock on an iOS version where it isnt public, check for the presence of NSDimension before proceeding.
-    if (objc_getClass("NSDimension"))
+    if (DEVICE_HIGHER_THAN_10)
     {
-        // Attempt to use 'os_unfair_lock_unlock'.
+        // Attempt to use os_unfair_lock_unlock().
         void (*os_unfair_lock_unlock)(void *lock) = dlsym(dlopen(NULL, RTLD_NOW | RTLD_GLOBAL), "os_unfair_lock_unlock");
         if (os_unfair_lock_unlock != NULL)
         {
@@ -80,11 +87,13 @@ static void chooseUnlock(void *lock)
     }
     
     // Unfair locks are not available on iOS 9 and lower, using deprecated OSSpinUnlock.
-    OSSpinLockUnlock(lock);
+    OSSpinLockUnlock((void *)lock);
 #endif
 }
 
+
 #pragma mark - Block Helpers
+
 #if !defined(NS_BLOCK_ASSERTIONS)
 
 // See http://clang.llvm.org/docs/Block-ABI-Apple.html#high-level
@@ -266,12 +275,7 @@ static void swizzle(Class classToSwizzle,
     NSCAssert(blockIsAnImpFactoryBlock(factoryBlock),
               @"Wrong type of implementation factory block.");
     
-#if TARGET_SDK_GE_10
     __block os_unfair_lock lock = OS_UNFAIR_LOCK_INIT;
-#else
-    // Below iOS 10, OS_UNFAIR_LOCK_INIT will not exist. Note that this type works with OSSpinLock
-    __block os_unfair_lock lock = ((os_unfair_lock){0});
-#endif
     
     // To keep things thread-safe, we fill in the originalIMP later,
     // with the result of the class_replaceMethod call below.


### PR DESCRIPTION
When building with the iOS 10 SDK, OSSpinLock() triggers warnings in Xcode as it has been deprecated. 

This pull request switches to Apple's replacement, os_unfair_lock ( https://developer.apple.com/reference/os/1646466-os_unfair_lock_lock ) when the base SDK is iOS 10+ or macOS 10.12+.